### PR TITLE
Add support for custom port and custom file format

### DIFF
--- a/precacher/__main__.py
+++ b/precacher/__main__.py
@@ -18,8 +18,10 @@ import dns.resolver
 
 LOG_FORMAT_DNSCRYPT_PROXY_TSV = 'dnscrypt-proxy-tsv'
 LOG_FORMAT_PIHOLE_DNSMASQ = 'pihole-dnsmasq'
+LOG_FORMAT_CUSTOM = 'custom-domain-type'
 LOG_FORMAT_CHOICES = {LOG_FORMAT_DNSCRYPT_PROXY_TSV,
-                      LOG_FORMAT_PIHOLE_DNSMASQ}
+                      LOG_FORMAT_PIHOLE_DNSMASQ,
+                      LOG_FORMAT_CUSTOM}
 
 LOG_FORMAT = '%(levelname)s:%(asctime)s %(message)s'
 ALLOWED_TYPES = {'A', 'AAAA'}
@@ -45,6 +47,10 @@ def parse_args(args):
                         default="192.168.1.1",
                         help="Comma-delimited list of DNS server IP "
                              "addresses.")
+    parser.add_argument("--port",
+                        default=53,
+                        type=int,
+                        help="Port at which to make requests to the nameservers")
     parser.add_argument("--top",
                         default=1000,
                         type=int,
@@ -79,13 +85,15 @@ def configure_resolver(args):
     logging.info("Replaying queries to: %r", nameservers)
     resolver = dns.resolver.Resolver(configure=False)
     resolver.nameservers = nameservers
+    resolver.port = args.port
     return resolver
 
 
 def summarize_queries(args):
     parser = {
         LOG_FORMAT_PIHOLE_DNSMASQ: parse_pihole_dnsmasq,
-        LOG_FORMAT_DNSCRYPT_PROXY_TSV: parse_dnscrypt_proxy_tsv
+        LOG_FORMAT_DNSCRYPT_PROXY_TSV: parse_dnscrypt_proxy_tsv,
+        LOG_FORMAT_CUSTOM: parse_custom_domain_list_tsv
     }[args.format]
 
     query_count = 0
@@ -107,6 +115,11 @@ def summarize_queries(args):
 def parse_dnscrypt_proxy_tsv(line):
     line = line.strip().split("\t")
     return Query(line[3], line[2])
+
+
+def parse_custom_domain_list_tsv(line):
+    line = line.strip().split("\t")
+    return Query(line[1], line[0])
 
 
 def parse_pihole_dnsmasq(line):


### PR DESCRIPTION
add commandline args for a different ports
Add a custom file type formatted as `DOMAIN\tTYPE`
For example, a custom-domain-type log file would have:
```
facebook.com    A
facebook.com    AAAA
```